### PR TITLE
fix: onChange prop to return DOM event rather than just the new value

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -132,8 +132,8 @@ const App = () => {
             <em>except when the escape key is pressed</em>)
           </li>
           <li>
-            <b>onChange</b> callback function returns the new value of the input
-            when it changes
+            <b>onChange</b> callback function returns the DOM event when the
+            input value changes
           </li>
           <li>
             <b>onEditMode</b> callback function is triggered when the component

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -14,6 +14,9 @@ const App = () => {
     'This is a controlled text area component'
   );
   const formatPrice = (val) => '$' + Math.round(parseFloat(val));
+  const handleChange = (e, setFn) => {
+    setFn(e.target.value);
+  };
   const handleSave = ({ name, value, previousValue }) => {
     alert(name + ' saved as: ' + value + ' (prev: ' + previousValue + ')');
   };
@@ -68,7 +71,7 @@ const App = () => {
                 <EditText
                   name='textbox1'
                   defaultValue='Click me to edit my text'
-                  inputClassName='bg-success form-control'
+                  inputClassName='bg-success'
                 />
                 <EditText
                   name='textbox2'
@@ -99,6 +102,13 @@ const App = () => {
           <li>
             <b>readonly</b> (default: false) displays only the view component
             and hides the input element
+          </li>
+          <li>
+            <b>className</b> sets the class attribute of the view component
+          </li>
+          <li>
+            <b>inputClassName</b> sets the class attribute of the input
+            component
           </li>
           <li>
             <b>style</b> sets the style of the DOM element
@@ -349,14 +359,14 @@ const App = () => {
                     marginBottom: '10px'
                   }}
                   value={price}
-                  onChange={setPrice}
+                  onChange={(e) => handleChange(e, setPrice)}
                   formatDisplayText={formatPrice}
                 />
                 <EditText
                   name='textbox'
                   style={{ fontSize: '16px', border: '1px solid #ccc' }}
                   value={text}
-                  onChange={setText}
+                  onChange={(e) => handleChange(e, setText)}
                   onSave={handleSave}
                 />
                 <p style={{ paddingLeft: '5px', marginBottom: '5px' }}>
@@ -369,7 +379,7 @@ const App = () => {
                   name='textarea'
                   style={{ fontSize: '16px', border: '1px solid #ccc' }}
                   value={textarea}
-                  onChange={setTextarea}
+                  onChange={(e) => handleChange(e, setTextarea)}
                   onSave={handleSave}
                 />
                 <p style={{ paddingLeft: '5px', marginBottom: '5px' }}>

--- a/example/src/examples.js
+++ b/example/src/examples.js
@@ -8,6 +8,7 @@ const App = () => {
             <EditText
               name="textbox1"
               defaultValue="Click me to edit my text"
+              inputClassName='bg-success'
             />
             <EditText
               name="textbox2"
@@ -108,6 +109,9 @@ const App = () => {
       'This is a controlled text area component'
     );
     const formatPrice = (val) => '$' + Math.round(parseFloat(val));
+    const handleChange = (e, setFn) => {
+      setFn(e.target.value);
+    };
     const handleSave = ({ name, value, previousValue }) => {
       alert(name + ' saved as: ' + value + ' (prev: ' + previousValue + ')');
     };
@@ -122,14 +126,14 @@ const App = () => {
               marginBottom: '10px'
             }}
             value={price}
-            onChange={setPrice}
+            onChange={(e) => handleChange(e, setPrice)}
             formatDisplayText={formatPrice}
           />
           <EditText
             name='textbox'
             style={{ fontSize: '16px', border: '1px solid #ccc' }}
             value={text}
-            onChange={setText}
+            onChange={(e) => handleChange(e, setText)}
             onSave={handleSave}
           />
           <p style={{ paddingLeft: '5px', marginBottom: '5px' }}>
@@ -142,7 +146,7 @@ const App = () => {
             name='textarea'
             style={{ fontSize: '16px', border: '1px solid #ccc' }}
             value={textarea}
-            onChange={setTextarea}
+            onChange={(e) => handleChange(e, setTextarea)}
             onSave={handleSave}
           />
           <p style={{ paddingLeft: '5px', marginBottom: '5px' }}>

--- a/src/EditText.js
+++ b/src/EditText.js
@@ -26,6 +26,7 @@ export default function EditText({
   inputClassName
 }) {
   const inputRef = React.useRef(null);
+  const [changeEvent, setChangeEvent] = React.useState({});
   const [previousValue, setPreviousValue] = React.useState('');
   const [savedText, setSavedText] = React.useState('');
   const [editMode, setEditMode] = React.useState(false);
@@ -69,7 +70,12 @@ export default function EditText({
         setSavedText(inputValue);
         setPreviousValue(inputValue);
       } else if (!save) {
-        onChange(previousValue);
+        onChange({
+          ...changeEvent,
+          target: changeEvent.target
+            ? { ...changeEvent.target, value: previousValue }
+            : { value: previousValue }
+        });
       }
       setEditMode(false);
       onBlur();
@@ -144,7 +150,8 @@ export default function EditText({
         {...sharedProps}
         value={value}
         onChange={(e) => {
-          onChange(e.target.value);
+          setChangeEvent(e);
+          onChange(e);
         }}
         inputClassName={inputClassName}
       />
@@ -158,7 +165,7 @@ export default function EditText({
   };
 
   return !readonly && editMode
-    ? renderEditMode(value !== undefined)
+    ? renderEditMode(value !== undefined && onChange !== undefined)
     : renderDisplayMode();
 }
 

--- a/src/EditTextarea.js
+++ b/src/EditTextarea.js
@@ -24,6 +24,7 @@ export default function EditTextarea({
   inputClassName
 }) {
   const inputRef = React.useRef(null);
+  const [changeEvent, setChangeEvent] = React.useState({});
   const [previousValue, setPreviousValue] = React.useState('');
   const [savedText, setSavedText] = React.useState('');
   const [editMode, setEditMode] = React.useState(false);
@@ -62,7 +63,12 @@ export default function EditTextarea({
         setSavedText(inputValue);
         setPreviousValue(inputValue);
       } else if (!save) {
-        onChange(previousValue);
+        onChange({
+          ...changeEvent,
+          target: changeEvent.target
+            ? { ...changeEvent.target, value: previousValue }
+            : { value: previousValue }
+        });
       }
       setEditMode(false);
       onBlur();
@@ -121,7 +127,8 @@ export default function EditTextarea({
         {...sharedProps}
         value={value}
         onChange={(e) => {
-          onChange(e.target.value);
+          setChangeEvent(e);
+          onChange(e);
         }}
         inputClassName={inputClassName}
       />
@@ -135,7 +142,7 @@ export default function EditTextarea({
   };
 
   return !readonly && editMode
-    ? renderEditMode(value !== undefined)
+    ? renderEditMode(value !== undefined && onChange !== undefined)
     : renderDisplayMode();
 }
 


### PR DESCRIPTION
## Description

- Refactored onChange prop to return DOM event rather than just the new value
- Need to store changeEvent in state to support blur / cancel save

Fixes #22

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the style guidelines of this project
- [x] I have updated the documentation accordingly where applicable.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
