### PR TITLE
Support 'auto' for rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ export default function Example() {
 
 | Prop | Type   | Required | Default | Description            |
 | ---- | ------ | -------- | ------- | ---------------------- |
-| rows | number | No       | 3       | Number of visible rows |
+| rows | number|'auto' | No       | 3       | Number of visible rows |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ export default function Example() {
 
 | Prop | Type   | Required | Default | Description            |
 | ---- | ------ | -------- | ------- | ---------------------- |
-| rows | number|'auto' | No       | 3       | Number of visible rows |
+| rows | number\|'auto' | No       | 3       | Number of visible rows |
 
 ## Contributing
 

--- a/src/EditTextarea.js
+++ b/src/EditTextarea.js
@@ -98,7 +98,7 @@ export default function EditTextarea({
         onClick={handleClick}
         style={{
           ...style,
-          height: rows == 'auto' ? 'auto' : `${rows * 24 + 16}px`
+          height: rows === 'auto' ? 'auto' : `${rows * 24 + 16}px`
         }}
         aria-label='display component'
       >

--- a/src/EditTextarea.js
+++ b/src/EditTextarea.js
@@ -98,7 +98,7 @@ export default function EditTextarea({
         onClick={handleClick}
         style={{
           ...style,
-          height: `${rows * 24 + 16}px`
+          height: rows == 'auto' ? 'auto' : `${rows * 24 + 16}px`
         }}
         aria-label='display component'
       >

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -56,7 +56,10 @@ export const EditTextDefaultProps = {
 
 export const EditTextareaPropTypes = {
   ...sharedPropTypes,
-  rows: PropTypes.number
+  rows: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.oneOfType(['auto']),
+  ]),
 };
 
 export const EditTextareaDefaultProps = {

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -58,8 +58,8 @@ export const EditTextareaPropTypes = {
   ...sharedPropTypes,
   rows: PropTypes.oneOfType([
     PropTypes.number,
-    PropTypes.oneOfType(['auto']),
-  ]),
+    PropTypes.oneOfType(['auto'])
+  ])
 };
 
 export const EditTextareaDefaultProps = {


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #54

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes Proposed

- Support `'auto'` as a value for `EditTextarea`'s `rows` parameter. This just sets the style `height: auto` instead of computing a fixed height.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the style guidelines of this project
- [X] I have updated the documentation accordingly where applicable.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
