### PR TITLE
[Fix] Remove default props in support of React 18.3

### DIFF
--- a/src/EditText.js
+++ b/src/EditText.js
@@ -1,28 +1,28 @@
 import classnames from 'classnames';
 import React from 'react';
 import Input from './components/Input';
-import { EditTextDefaultProps, EditTextPropTypes } from './propTypes';
+import { EditTextPropTypes } from './propTypes';
 import styles from './styles.module.css';
 
 export default function EditText({
   id,
   name,
   className,
-  placeholder,
-  inline,
-  style,
-  readonly,
-  type,
+  placeholder = '',
+  inline = false,
+  style = {},
+  readonly = false,
+  type = 'text',
   value,
   defaultValue,
-  formatDisplayText,
-  onEditMode,
-  onChange,
-  onSave,
-  onBlur,
-  showEditButton,
-  editButtonContent,
-  editButtonProps,
+  formatDisplayText = (x) => x,
+  onEditMode = () => {},
+  onChange = () => {},
+  onSave = () => {},
+  onBlur = () => {},
+  showEditButton = false,
+  editButtonContent = <EditIcon />,
+  editButtonProps = {},
   inputClassName
 }) {
   const inputRef = React.useRef(null);
@@ -171,5 +171,4 @@ export default function EditText({
     : renderDisplayMode();
 }
 
-EditText.defaultProps = EditTextDefaultProps;
 EditText.propTypes = EditTextPropTypes;

--- a/src/EditText.js
+++ b/src/EditText.js
@@ -1,5 +1,6 @@
 import classnames from 'classnames';
 import React from 'react';
+import EditIcon from './components/EditIcon';
 import Input from './components/Input';
 import { EditTextPropTypes } from './propTypes';
 import styles from './styles.module.css';

--- a/src/EditTextarea.js
+++ b/src/EditTextarea.js
@@ -1,26 +1,26 @@
 import classnames from 'classnames';
 import React from 'react';
 import Textarea from './components/Textarea';
-import { EditTextareaDefaultProps, EditTextareaPropTypes } from './propTypes';
+import { EditTextareaPropTypes } from './propTypes';
 import styles from './styles.module.css';
 
 const splitLines = (val) => (val ? val.split(/\r?\n/) : []);
 
 export default function EditTextarea({
   id,
-  rows,
+  rows = 3,
   name,
   className,
-  placeholder,
-  style,
-  readonly,
+  placeholder = '',
+  style = {},
+  readonly = false,
   value,
   defaultValue,
-  formatDisplayText,
-  onEditMode,
-  onChange,
-  onSave,
-  onBlur,
+  formatDisplayText = (x) => x,
+  onEditMode = () => {},
+  onChange = () => {},
+  onSave = () => {},
+  onBlur = () => {},
   inputClassName
 }) {
   const inputRef = React.useRef(null);
@@ -148,5 +148,4 @@ export default function EditTextarea({
     : renderDisplayMode();
 }
 
-EditTextarea.defaultProps = EditTextareaDefaultProps;
 EditTextarea.propTypes = EditTextareaPropTypes;

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import EditIcon from './components/EditIcon';
 
 const sharedPropTypes = {
   id: PropTypes.string,

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -2,23 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import EditIcon from './components/EditIcon';
 
-const sharedDefaultProps = {
-  id: undefined,
-  name: undefined,
-  className: undefined,
-  value: undefined,
-  formatDisplayText: (x) => x,
-  defaultValue: undefined,
-  placeholder: '',
-  onSave: () => {},
-  onChange: () => {},
-  onEditMode: () => {},
-  onBlur: () => {},
-  style: {},
-  readonly: false,
-  inputClassName: undefined
-};
-
 const sharedPropTypes = {
   id: PropTypes.string,
   name: PropTypes.string,
@@ -45,21 +28,7 @@ export const EditTextPropTypes = {
   editButtonProps: PropTypes.object
 };
 
-export const EditTextDefaultProps = {
-  ...sharedDefaultProps,
-  type: 'text',
-  inline: false,
-  showEditButton: false,
-  editButtonContent: <EditIcon />,
-  editButtonProps: {}
-};
-
 export const EditTextareaPropTypes = {
   ...sharedPropTypes,
   rows: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(['auto'])])
-};
-
-export const EditTextareaDefaultProps = {
-  ...sharedDefaultProps,
-  rows: 3
 };

--- a/src/propTypes.js
+++ b/src/propTypes.js
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import React from 'react';
 
 const sharedPropTypes = {
   id: PropTypes.string,


### PR DESCRIPTION
## Description

React 18.3.0 will deprecate the use of defaultProps as a means of passing props into function components. This PR alleviates this problem in every instance of the codebase.

Currently the codebase uses `defaultProps` which is an outdated way of passing props. Now we can restructure props inside the component itself and assign default values.


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the style guidelines of this project
- [x] I have updated the documentation accordingly where applicable.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
